### PR TITLE
Fixed bookmark images in dev guide not showing up

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -361,11 +361,11 @@ The following are the sequence diagrams each command +
 Bookmarking a place which is already bookmarked will throw `DuplicateTagException` since `addTag` can
 be used by other commands or methods.
 
-image::BookmarkSequenceDiagram.png[width="800"]
+image::BookmarkSequenceDiagram.PNG[width="800"]
 
 `clear_bookmark` command
 
-image::ClearBookmarkSequenceDiagram.png[width="800"]
+image::ClearBookmarkSequenceDiagram.PNG[width="800"]
 
 Both commands are quite similar, only slightly difference is additional index argument for `bookmark`, and calling different
 methods in `ModelManager`.


### PR DESCRIPTION
Compatibility issue in Dev Guide where .png photos being fetched instead of .PNG