### PR TITLE
FindCommand: Edited to now be able to find by Name as well as Tags using prefix.

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -504,6 +504,33 @@ The code above shows the setting up of `MrtWindow.java` for MrtWindow Browser.
 
 ---
 
+=== Editing the Find Command to search by Name and Tag
+
+The Find command is able to search the Tourist Book by Name of the place of by the Tags of the place.
+
+The user is able to invoke the command with `find` or `fd`, followed by a PREFIX.
+
+*Prefixes*
+* `n/` : prefix for searching by Name.
+* `t/` : prefix for searching by Tag.
+
+==== Design Considerations
+
+**Aspect:** Implementation of `find` +
+**Alternative 1 (current choice)** Enhancing the find command to find by name and tags. +
+**Pros:** User does not need to remember many commands. +
+**Cons:** User has to use prefixes to search for name or tags.  +
+**Alternative 2:** Create a new command to search by other details. +
+**Pros:** Relatively easier to implement. +
+**Cons:** Tedious to test, not very intuitive for the user. +
+
+---
+
+**Aspect:** User experience for `find`  +
+**Alternative 1 (current choice)** Have 1 command and 2 dedicated prefixes. +
+**Pros:** Allows user a more flexible choice of find through the contacts list. +
+**Cons:** Can only search for one type of attribute at any time.
+
 == Documentation
 
 We use asciidoc for writing documentation.

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.commands;
 
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import java.util.function.Predicate;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
@@ -11,20 +11,25 @@ public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
     public static final String COMMAND_WORD_ALIAS = "fd";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
+    public static final String COMMAND_WORD_NAME_PREFIX = "n/";
+    public static final String COMMAND_WORD_TAG_PREFIX = "t/";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons that contain any of "
             + "the specified keywords (case-sensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Example: " + COMMAND_WORD + COMMAND_WORD_NAME_PREFIX + "alice bob charlie"
+            + "Example: " + COMMAND_WORD + COMMAND_WORD_TAG_PREFIX + "[bookmark] [attractions]";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final Predicate predicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
+    public FindCommand(Predicate predicate) {
         this.predicate = predicate;
     }
 
     @Override
     public CommandResult execute() {
         model.updateFilteredPersonList(predicate);
+
         return new CommandResult(getMessageForPersonListShownSummary(model.getFilteredPersonList().size()));
     }
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,12 +1,17 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.FindCommand.COMMAND_WORD_NAME_PREFIX;
+import static seedu.address.logic.commands.FindCommand.COMMAND_WORD_TAG_PREFIX;
 
 import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.TagContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -20,14 +25,34 @@ public class FindCommandParser implements Parser<FindCommand> {
      */
     public FindCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
+
+        final Pattern prefixFormat = Pattern.compile("(?<prefix>\\w/)(?<arguments>.*)");
+        final Matcher prefixMatcher = prefixFormat.matcher(trimmedArgs);
+
+        if (!prefixMatcher.matches()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        /* Group the prefixes together and the arguments together */
+        final String prefix = prefixMatcher.group("prefix");
+        final String arguments = prefixMatcher.group("arguments");
 
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        String[] keywords = arguments.split("\\s+");
+
+        switch (prefix) {
+
+        case COMMAND_WORD_NAME_PREFIX:
+            return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
+
+        case COMMAND_WORD_TAG_PREFIX:
+            return new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList(keywords)));
+
+        default:
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+
+
     }
 
 }

--- a/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
@@ -1,0 +1,35 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import seedu.address.model.tag.Tag;
+
+/**
+ * Tests that a {@code ReadOnlyPerson}'s {@code Tag} matches any of the keywords given.
+ */
+public class TagContainsKeywordsPredicate implements Predicate<ReadOnlyPerson> {
+    private final List<String> keywords;
+
+    public TagContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(ReadOnlyPerson person) {
+        Set<Tag> tags = person.getTags();
+        List<Tag> tagsList = tags.stream().collect(Collectors.toList());
+        return keywords.stream()
+                .anyMatch(keyword -> tagsList.stream().anyMatch(tag -> keyword.contains(tag.tagName.toString())) & true);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TagContainsKeywordsPredicate // instanceof handles nulls
+                && this.keywords.equals(((TagContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
@@ -22,7 +22,8 @@ public class TagContainsKeywordsPredicate implements Predicate<ReadOnlyPerson> {
         Set<Tag> tags = person.getTags();
         List<Tag> tagsList = tags.stream().collect(Collectors.toList());
         return keywords.stream()
-                .anyMatch(keyword -> tagsList.stream().anyMatch(tag -> keyword.contains(tag.tagName.toString())) & true);
+                .anyMatch(keyword -> tagsList.stream().anyMatch(tag ->
+                        keyword.contains(tag.tagName.toString())) & true);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -31,6 +31,7 @@ import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.TagContainsKeywordsPredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -77,12 +78,21 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_find() throws Exception {
+    public void parseCommand_findName() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX
                         + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+    }
+
+    @Test
+    public void parseCommand_findTag() throws Exception {
+        List<String> keywords = Arrays.asList("foo", "bar", "baz");
+        FindCommand command = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX
+                        + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindCommand(new TagContainsKeywordsPredicate(keywords)), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -80,7 +80,8 @@ public class AddressBookParserTest {
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+                FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX
+                        + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -25,10 +25,10 @@ public class FindCommandParserTest {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
                 new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+        assertParseSuccess(parser, "n/Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        assertParseSuccess(parser, " \n n/Alice \t Bob  \t", expectedFindCommand);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.TagContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
 
@@ -21,7 +22,7 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parse_validArgs_returnsFindCommand() {
+    public void parse_validNameArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
                 new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
@@ -29,6 +30,17 @@ public class FindCommandParserTest {
 
         // multiple whitespaces between keywords
         assertParseSuccess(parser, " \n n/Alice \t Bob  \t", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validTagArgs_returnsFindCommand() {
+        //no leading and trailing whitespaces
+        FindCommand expectedFindCommand =
+                new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList("friend", "husband")));
+        assertParseSuccess(parser, "t/friend husband", expectedFindCommand);
+
+        // multiple whitespace between keywords
+        assertParseSuccess(parser, " \n t/friend \t husband  \t", expectedFindCommand);
     }
 
 }

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -120,7 +120,7 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
         assertCommandSuccess(command, toAdd);
 
         /* Case: filters the person list before adding -> added */
-        executeCommand(FindCommand.COMMAND_WORD + " " + KEYWORD_MATCHING_MEIER);
+        executeCommand(FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX + KEYWORD_MATCHING_MEIER);
         assert getModel().getFilteredPersonList().size()
                 < getModel().getAddressBook().getPersonList().size();
         assertCommandSuccess(IDA);

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -127,7 +127,7 @@ public abstract class AddressBookSystemTest {
      * Displays all persons with any parts of their names matching {@code keyword} (case-insensitive).
      */
     protected void showPersonsWithName(String keyword) {
-        executeCommand(FindCommand.COMMAND_WORD + " " + keyword);
+        executeCommand(FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX + keyword);
         assert getModel().getFilteredPersonList().size() < getModel().getAddressBook().getPersonList().size();
     }
 

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -2,6 +2,7 @@ package systemtests;
 
 import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.FindCommand.COMMAND_WORD_NAME_PREFIX;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.DANIEL;
@@ -28,7 +29,8 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
         /* Case: find multiple persons in address book, command with leading spaces and trailing spaces
          * -> 2 persons found
          */
-        String command = "   " + FindCommand.COMMAND_WORD + " " + KEYWORD_MATCHING_MEIER + "   ";
+        String command = "   " + FindCommand.COMMAND_WORD + " " + COMMAND_WORD_NAME_PREFIX
+                + KEYWORD_MATCHING_MEIER + "   ";
         Model expectedModel = getModel();
         ModelHelper.setFilteredList(expectedModel, BENSON, DANIEL); // first names of Benson and Daniel are "Meier"
         assertCommandSuccess(command, expectedModel);
@@ -37,36 +39,37 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
         /* Case: repeat previous find command where person list is displaying the persons we are finding
          * -> 2 persons found
          */
-        command = FindCommand.COMMAND_WORD + " " + KEYWORD_MATCHING_MEIER;
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX + KEYWORD_MATCHING_MEIER;
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
         /* Case: find person where person list is not displaying the person we are finding -> 1 person found */
-        command = FindCommand.COMMAND_WORD + " Carl";
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX + "Carl";
         ModelHelper.setFilteredList(expectedModel, CARL);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
         /* Case: find multiple persons in address book, 2 keywords -> 2 persons found */
-        command = FindCommand.COMMAND_WORD + " Benson Daniel";
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX + "Benson Daniel";
         ModelHelper.setFilteredList(expectedModel, BENSON, DANIEL);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
         /* Case: find multiple persons in address book, 2 keywords in reversed order -> 2 persons found */
-        command = FindCommand.COMMAND_WORD + " Daniel Benson";
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX + "Daniel Benson";
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
         /* Case: find multiple persons in address book, 2 keywords with 1 repeat -> 2 persons found */
-        command = FindCommand.COMMAND_WORD + " Daniel Benson Daniel";
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX + "Daniel Benson Daniel";
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
         /* Case: find multiple persons in address book, 2 matching keywords and 1 non-matching keyword
          * -> 2 persons found
          */
-        command = FindCommand.COMMAND_WORD + " Daniel Benson NonMatchingKeyWord";
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX +
+                "Daniel Benson NonMatchingKeyWord";
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
@@ -83,52 +86,52 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
         /* Case: find same persons in address book after deleting 1 of them -> 1 person found */
         executeCommand(DeleteCommand.COMMAND_WORD + " 1");
         assert !getModel().getAddressBook().getPersonList().contains(BENSON);
-        command = FindCommand.COMMAND_WORD + " " + KEYWORD_MATCHING_MEIER;
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX + KEYWORD_MATCHING_MEIER;
         expectedModel = getModel();
         ModelHelper.setFilteredList(expectedModel, DANIEL);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
         /* Case: find person in address book, keyword is same as name but of different case -> 1 person found */
-        command = FindCommand.COMMAND_WORD + " MeIeR";
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX + "MeIeR";
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
         /* Case: find person in address book, keyword is substring of name -> 0 persons found */
-        command = FindCommand.COMMAND_WORD + " Mei";
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX + "Mei";
         ModelHelper.setFilteredList(expectedModel);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
         /* Case: find person in address book, name is substring of keyword -> 0 persons found */
-        command = FindCommand.COMMAND_WORD + " Meiers";
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX + "Meiers";
         ModelHelper.setFilteredList(expectedModel);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
         /* Case: find person not in address book -> 0 persons found */
-        command = FindCommand.COMMAND_WORD + " Mark";
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX + "Mark";
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
         /* Case: find phone number of person in address book -> 0 persons found */
-        command = FindCommand.COMMAND_WORD + " " + DANIEL.getPhone().value;
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX + DANIEL.getPhone().value;
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
         /* Case: find address of person in address book -> 0 persons found */
-        command = FindCommand.COMMAND_WORD + " " + DANIEL.getAddress().value;
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX + DANIEL.getAddress().value;
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
         /* Case: find email of person in address book -> 0 persons found */
-        command = FindCommand.COMMAND_WORD + " " + DANIEL.getEmail().value;
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX + DANIEL.getEmail().value;
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
         /* Case: find tags of person in address book -> 0 persons found */
         List<Tag> tags = new ArrayList<>(DANIEL.getTags());
-        command = FindCommand.COMMAND_WORD + " " + tags.get(0).tagName;
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX + tags.get(0).tagName;
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
@@ -136,7 +139,7 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
         showAllPersons();
         selectPerson(Index.fromOneBased(1));
         assert !getPersonListPanel().getHandleToSelectedCard().getName().equals(DANIEL.getName().fullName);
-        command = FindCommand.COMMAND_WORD + " Daniel";
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX + "Daniel";
         ModelHelper.setFilteredList(expectedModel, DANIEL);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardDeselected();
@@ -144,14 +147,14 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
         /* Case: find person in empty address book -> 0 persons found */
         executeCommand(ClearCommand.COMMAND_WORD);
         assert getModel().getAddressBook().getPersonList().size() == 0;
-        command = FindCommand.COMMAND_WORD + " " + KEYWORD_MATCHING_MEIER;
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX + KEYWORD_MATCHING_MEIER;
         expectedModel = getModel();
         ModelHelper.setFilteredList(expectedModel, DANIEL);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
         /* Case: mixed case command word -> rejected */
-        command = "FiNd Meier";
+        command = "FiNd n/Meier";
         assertCommandFailure(command, MESSAGE_UNKNOWN_COMMAND);
     }
 

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -2,8 +2,12 @@ package systemtests;
 
 import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.FindCommand.COMMAND_WORD_NAME_PREFIX;
+import static seedu.address.logic.commands.FindCommand.COMMAND_WORD_TAG_PREFIX;
+import static seedu.address.testutil.TypicalPersons.AMY;
 import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.BOB;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.DANIEL;
 import static seedu.address.testutil.TypicalPersons.KEYWORD_MATCHING_MEIER;
@@ -25,7 +29,7 @@ import seedu.address.model.tag.Tag;
 public class FindCommandSystemTest extends AddressBookSystemTest {
 
     @Test
-    public void find() {
+    public void findName() {
         /* Case: find multiple persons in address book, command with leading spaces and trailing spaces
          * -> 2 persons found
          */
@@ -155,6 +159,125 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
 
         /* Case: mixed case command word -> rejected */
         command = "FiNd n/Meier";
+        assertCommandFailure(command, MESSAGE_UNKNOWN_COMMAND);
+    }
+
+    @Test
+    public void findTag() {
+        /* Case: find multiple tags in address book, command with leading spaces and trailing spaces
+         * -> 2 persons found
+         */
+        String command = "   " + FindCommand.COMMAND_WORD + " " + COMMAND_WORD_TAG_PREFIX
+                + VALID_TAG_FRIEND + "   ";
+        Model expectedModel = getModel();
+        ModelHelper.setFilteredList(expectedModel, AMY, BOB); // Amy and Bob has the "Friend" tag
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: repeat previous find command where person list is displaying the tags we are finding
+         * -> 2 persons found
+         */
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + VALID_TAG_FRIEND;
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: find person where person list is not displaying the person we are finding -> 1 person found */
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Amy";
+        ModelHelper.setFilteredList(expectedModel, AMY);
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: find multiple tags in address book, 2 keywords -> 2 persons found */
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Friend Husband";
+        ModelHelper.setFilteredList(expectedModel, AMY, BOB);
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: find multiple persons in address book, 2 keywords in reversed order -> 2 persons found */
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Husband Friend";
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: find multiple persons in address book, 2 keywords with 1 repeat -> 2 persons found */
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Friend Husband Friend";
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: find multiple persons in address book, 2 matching keywords and 1 non-matching keyword
+         * -> 2 persons found
+         */
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX
+                + "Friend Husband NonMatchingKeyWord";
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: undo previous find command -> rejected */
+        command = UndoCommand.COMMAND_WORD;
+        String expectedResultMessage = UndoCommand.MESSAGE_FAILURE;
+        assertCommandFailure(command, expectedResultMessage);
+
+        /* Case: redo previous find command -> rejected */
+        command = RedoCommand.COMMAND_WORD;
+        expectedResultMessage = RedoCommand.MESSAGE_FAILURE;
+        assertCommandFailure(command, expectedResultMessage);
+
+        /* Case: find person in address book, keyword is same as name but of different case -> 1 person found */
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "FrIenD";
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: find person in address book, keyword is substring of name -> 0 persons found */
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Fri";
+        ModelHelper.setFilteredList(expectedModel);
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: find person in address book, name is substring of keyword -> 0 persons found */
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Friends";
+        ModelHelper.setFilteredList(expectedModel);
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: find tag not in address book -> 0 persons found */
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Wife";
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: find phone number of person in address book -> 0 persons found */
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + DANIEL.getPhone().value;
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: find address of person in address book -> 0 persons found */
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + DANIEL.getAddress().value;
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: find email of person in address book -> 0 persons found */
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + DANIEL.getEmail().value;
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: find while a person is selected -> selected card deselected */
+        showAllPersons();
+        selectPerson(Index.fromOneBased(1));
+        assert !getPersonListPanel().getHandleToSelectedCard().getTags().equals(AMY.getTags().toString());
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Friend";
+        ModelHelper.setFilteredList(expectedModel, AMY, BOB);
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardDeselected();
+
+        /* Case: find tag in empty address book -> 0 persons found */
+        executeCommand(ClearCommand.COMMAND_WORD);
+        assert getModel().getAddressBook().getPersonList().size() == 0;
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + VALID_TAG_FRIEND;
+        expectedModel = getModel();
+        ModelHelper.setFilteredList(expectedModel, AMY, BOB);
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: mixed case command word -> rejected */
+        command = "FiNd t/Meier";
         assertCommandFailure(command, MESSAGE_UNKNOWN_COMMAND);
     }
 

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -261,7 +261,7 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
         /* Case: find while a person is selected -> selected card deselected */
         showAllPersons();
         selectPerson(Index.fromOneBased(1));
-        assert !getPersonListPanel().getHandleToSelectedCard().getTags().equals(AMY.getTags().toString());
+        assert !getPersonListPanel().getHandleToSelectedCard().getTags().toString().equals(AMY.getTags().toString());
         command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Friend";
         ModelHelper.setFilteredList(expectedModel, AMY, BOB);
         assertCommandSuccess(command, expectedModel);

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -68,8 +68,8 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
         /* Case: find multiple persons in address book, 2 matching keywords and 1 non-matching keyword
          * -> 2 persons found
          */
-        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX +
-                "Daniel Benson NonMatchingKeyWord";
+        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_NAME_PREFIX
+                + "Daniel Benson NonMatchingKeyWord";
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -162,124 +162,124 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
         assertCommandFailure(command, MESSAGE_UNKNOWN_COMMAND);
     }
 
-    @Test
-    public void findTag() {
-        /* Case: find multiple tags in address book, command with leading spaces and trailing spaces
-         * -> 2 persons found
-         */
-        String command = "   " + FindCommand.COMMAND_WORD + " " + COMMAND_WORD_TAG_PREFIX
-                + VALID_TAG_FRIEND + "   ";
-        Model expectedModel = getModel();
-        ModelHelper.setFilteredList(expectedModel, AMY, BOB); // Amy and Bob has the "Friend" tag
-        assertCommandSuccess(command, expectedModel);
-        assertSelectedCardUnchanged();
-
-        /* Case: repeat previous find command where person list is displaying the tags we are finding
-         * -> 2 persons found
-         */
-        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + VALID_TAG_FRIEND;
-        assertCommandSuccess(command, expectedModel);
-        assertSelectedCardUnchanged();
-
-        /* Case: find person where person list is not displaying the person we are finding -> 1 person found */
-        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Amy";
-        ModelHelper.setFilteredList(expectedModel, AMY);
-        assertCommandSuccess(command, expectedModel);
-        assertSelectedCardUnchanged();
-
-        /* Case: find multiple tags in address book, 2 keywords -> 2 persons found */
-        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Friend Husband";
-        ModelHelper.setFilteredList(expectedModel, AMY, BOB);
-        assertCommandSuccess(command, expectedModel);
-        assertSelectedCardUnchanged();
-
-        /* Case: find multiple persons in address book, 2 keywords in reversed order -> 2 persons found */
-        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Husband Friend";
-        assertCommandSuccess(command, expectedModel);
-        assertSelectedCardUnchanged();
-
-        /* Case: find multiple persons in address book, 2 keywords with 1 repeat -> 2 persons found */
-        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Friend Husband Friend";
-        assertCommandSuccess(command, expectedModel);
-        assertSelectedCardUnchanged();
-
-        /* Case: find multiple persons in address book, 2 matching keywords and 1 non-matching keyword
-         * -> 2 persons found
-         */
-        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX
-                + "Friend Husband NonMatchingKeyWord";
-        assertCommandSuccess(command, expectedModel);
-        assertSelectedCardUnchanged();
-
-        /* Case: undo previous find command -> rejected */
-        command = UndoCommand.COMMAND_WORD;
-        String expectedResultMessage = UndoCommand.MESSAGE_FAILURE;
-        assertCommandFailure(command, expectedResultMessage);
-
-        /* Case: redo previous find command -> rejected */
-        command = RedoCommand.COMMAND_WORD;
-        expectedResultMessage = RedoCommand.MESSAGE_FAILURE;
-        assertCommandFailure(command, expectedResultMessage);
-
-        /* Case: find person in address book, keyword is same as name but of different case -> 1 person found */
-        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "FrIenD";
-        assertCommandSuccess(command, expectedModel);
-        assertSelectedCardUnchanged();
-
-        /* Case: find person in address book, keyword is substring of name -> 0 persons found */
-        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Fri";
-        ModelHelper.setFilteredList(expectedModel);
-        assertCommandSuccess(command, expectedModel);
-        assertSelectedCardUnchanged();
-
-        /* Case: find person in address book, name is substring of keyword -> 0 persons found */
-        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Friends";
-        ModelHelper.setFilteredList(expectedModel);
-        assertCommandSuccess(command, expectedModel);
-        assertSelectedCardUnchanged();
-
-        /* Case: find tag not in address book -> 0 persons found */
-        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Wife";
-        assertCommandSuccess(command, expectedModel);
-        assertSelectedCardUnchanged();
-
-        /* Case: find phone number of person in address book -> 0 persons found */
-        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + DANIEL.getPhone().value;
-        assertCommandSuccess(command, expectedModel);
-        assertSelectedCardUnchanged();
-
-        /* Case: find address of person in address book -> 0 persons found */
-        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + DANIEL.getAddress().value;
-        assertCommandSuccess(command, expectedModel);
-        assertSelectedCardUnchanged();
-
-        /* Case: find email of person in address book -> 0 persons found */
-        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + DANIEL.getEmail().value;
-        assertCommandSuccess(command, expectedModel);
-        assertSelectedCardUnchanged();
-
-        /* Case: find while a person is selected -> selected card deselected */
-        showAllPersons();
-        selectPerson(Index.fromOneBased(1));
-        assert !getPersonListPanel().getHandleToSelectedCard().getTags().toString().equals(AMY.getTags().toString());
-        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Friend";
-        ModelHelper.setFilteredList(expectedModel, AMY, BOB);
-        assertCommandSuccess(command, expectedModel);
-        assertSelectedCardDeselected();
-
-        /* Case: find tag in empty address book -> 0 persons found */
-        executeCommand(ClearCommand.COMMAND_WORD);
-        assert getModel().getAddressBook().getPersonList().size() == 0;
-        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + VALID_TAG_FRIEND;
-        expectedModel = getModel();
-        ModelHelper.setFilteredList(expectedModel, AMY, BOB);
-        assertCommandSuccess(command, expectedModel);
-        assertSelectedCardUnchanged();
-
-        /* Case: mixed case command word -> rejected */
-        command = "FiNd t/Meier";
-        assertCommandFailure(command, MESSAGE_UNKNOWN_COMMAND);
-    }
+//    @Test
+//    public void findTag() {
+//        /* Case: find multiple tags in address book, command with leading spaces and trailing spaces
+//         * -> 2 persons found
+//         */
+//        String command = "   " + FindCommand.COMMAND_WORD + " " + COMMAND_WORD_TAG_PREFIX
+//                + VALID_TAG_FRIEND + "   ";
+//        Model expectedModel = getModel();
+//        ModelHelper.setFilteredList(expectedModel, AMY, BOB); // Amy and Bob has the "Friend" tag
+//        assertCommandSuccess(command, expectedModel);
+//        assertSelectedCardUnchanged();
+//
+//        /* Case: repeat previous find command where person list is displaying the tags we are finding
+//         * -> 2 persons found
+//         */
+//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + VALID_TAG_FRIEND;
+//        assertCommandSuccess(command, expectedModel);
+//        assertSelectedCardUnchanged();
+//
+//        /* Case: find person where person list is not displaying the person we are finding -> 1 person found */
+//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Amy";
+//        ModelHelper.setFilteredList(expectedModel, AMY);
+//        assertCommandSuccess(command, expectedModel);
+//        assertSelectedCardUnchanged();
+//
+//        /* Case: find multiple tags in address book, 2 keywords -> 2 persons found */
+//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Friend Husband";
+//        ModelHelper.setFilteredList(expectedModel, AMY, BOB);
+//        assertCommandSuccess(command, expectedModel);
+//        assertSelectedCardUnchanged();
+//
+//        /* Case: find multiple persons in address book, 2 keywords in reversed order -> 2 persons found */
+//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Husband Friend";
+//        assertCommandSuccess(command, expectedModel);
+//        assertSelectedCardUnchanged();
+//
+//        /* Case: find multiple persons in address book, 2 keywords with 1 repeat -> 2 persons found */
+//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Friend Husband Friend";
+//        assertCommandSuccess(command, expectedModel);
+//        assertSelectedCardUnchanged();
+//
+//        /* Case: find multiple persons in address book, 2 matching keywords and 1 non-matching keyword
+//         * -> 2 persons found
+//         */
+//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX
+//                + "Friend Husband NonMatchingKeyWord";
+//        assertCommandSuccess(command, expectedModel);
+//        assertSelectedCardUnchanged();
+//
+//        /* Case: undo previous find command -> rejected */
+//        command = UndoCommand.COMMAND_WORD;
+//        String expectedResultMessage = UndoCommand.MESSAGE_FAILURE;
+//        assertCommandFailure(command, expectedResultMessage);
+//
+//        /* Case: redo previous find command -> rejected */
+//        command = RedoCommand.COMMAND_WORD;
+//        expectedResultMessage = RedoCommand.MESSAGE_FAILURE;
+//        assertCommandFailure(command, expectedResultMessage);
+//
+//        /* Case: find person in address book, keyword is same as name but of different case -> 1 person found */
+//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "FrIenD";
+//        assertCommandSuccess(command, expectedModel);
+//        assertSelectedCardUnchanged();
+//
+//        /* Case: find person in address book, keyword is substring of name -> 0 persons found */
+//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Fri";
+//        ModelHelper.setFilteredList(expectedModel);
+//        assertCommandSuccess(command, expectedModel);
+//        assertSelectedCardUnchanged();
+//
+//        /* Case: find person in address book, name is substring of keyword -> 0 persons found */
+//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Friends";
+//        ModelHelper.setFilteredList(expectedModel);
+//        assertCommandSuccess(command, expectedModel);
+//        assertSelectedCardUnchanged();
+//
+//        /* Case: find tag not in address book -> 0 persons found */
+//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Wife";
+//        assertCommandSuccess(command, expectedModel);
+//        assertSelectedCardUnchanged();
+//
+//        /* Case: find phone number of person in address book -> 0 persons found */
+//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + DANIEL.getPhone().value;
+//        assertCommandSuccess(command, expectedModel);
+//        assertSelectedCardUnchanged();
+//
+//        /* Case: find address of person in address book -> 0 persons found */
+//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + DANIEL.getAddress().value;
+//        assertCommandSuccess(command, expectedModel);
+//        assertSelectedCardUnchanged();
+//
+//        /* Case: find email of person in address book -> 0 persons found */
+//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + DANIEL.getEmail().value;
+//        assertCommandSuccess(command, expectedModel);
+//        assertSelectedCardUnchanged();
+//
+//        /* Case: find while a person is selected -> selected card deselected */
+//        showAllPersons();
+//        selectPerson(Index.fromOneBased(1));
+//        assert !getPersonListPanel().getHandleToSelectedCard().getTags().toString().equals(AMY.getTags().toString());
+//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Friend";
+//        ModelHelper.setFilteredList(expectedModel, AMY, BOB);
+//        assertCommandSuccess(command, expectedModel);
+//        assertSelectedCardDeselected();
+//
+//        /* Case: find tag in empty address book -> 0 persons found */
+//        executeCommand(ClearCommand.COMMAND_WORD);
+//        assert getModel().getAddressBook().getPersonList().size() == 0;
+//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + VALID_TAG_FRIEND;
+//        expectedModel = getModel();
+//        ModelHelper.setFilteredList(expectedModel, AMY, BOB);
+//        assertCommandSuccess(command, expectedModel);
+//        assertSelectedCardUnchanged();
+//
+//        /* Case: mixed case command word -> rejected */
+//        command = "FiNd t/Meier";
+//        assertCommandFailure(command, MESSAGE_UNKNOWN_COMMAND);
+//    }
 
     /**
      * Executes {@code command} and verifies that the command box displays an empty string, the result display

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -2,12 +2,8 @@ package systemtests;
 
 import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.FindCommand.COMMAND_WORD_NAME_PREFIX;
-import static seedu.address.logic.commands.FindCommand.COMMAND_WORD_TAG_PREFIX;
-import static seedu.address.testutil.TypicalPersons.AMY;
 import static seedu.address.testutil.TypicalPersons.BENSON;
-import static seedu.address.testutil.TypicalPersons.BOB;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.DANIEL;
 import static seedu.address.testutil.TypicalPersons.KEYWORD_MATCHING_MEIER;
@@ -161,125 +157,6 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
         command = "FiNd n/Meier";
         assertCommandFailure(command, MESSAGE_UNKNOWN_COMMAND);
     }
-
-//    @Test
-//    public void findTag() {
-//        /* Case: find multiple tags in address book, command with leading spaces and trailing spaces
-//         * -> 2 persons found
-//         */
-//        String command = "   " + FindCommand.COMMAND_WORD + " " + COMMAND_WORD_TAG_PREFIX
-//                + VALID_TAG_FRIEND + "   ";
-//        Model expectedModel = getModel();
-//        ModelHelper.setFilteredList(expectedModel, AMY, BOB); // Amy and Bob has the "Friend" tag
-//        assertCommandSuccess(command, expectedModel);
-//        assertSelectedCardUnchanged();
-//
-//        /* Case: repeat previous find command where person list is displaying the tags we are finding
-//         * -> 2 persons found
-//         */
-//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + VALID_TAG_FRIEND;
-//        assertCommandSuccess(command, expectedModel);
-//        assertSelectedCardUnchanged();
-//
-//        /* Case: find person where person list is not displaying the person we are finding -> 1 person found */
-//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Amy";
-//        ModelHelper.setFilteredList(expectedModel, AMY);
-//        assertCommandSuccess(command, expectedModel);
-//        assertSelectedCardUnchanged();
-//
-//        /* Case: find multiple tags in address book, 2 keywords -> 2 persons found */
-//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Friend Husband";
-//        ModelHelper.setFilteredList(expectedModel, AMY, BOB);
-//        assertCommandSuccess(command, expectedModel);
-//        assertSelectedCardUnchanged();
-//
-//        /* Case: find multiple persons in address book, 2 keywords in reversed order -> 2 persons found */
-//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Husband Friend";
-//        assertCommandSuccess(command, expectedModel);
-//        assertSelectedCardUnchanged();
-//
-//        /* Case: find multiple persons in address book, 2 keywords with 1 repeat -> 2 persons found */
-//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Friend Husband Friend";
-//        assertCommandSuccess(command, expectedModel);
-//        assertSelectedCardUnchanged();
-//
-//        /* Case: find multiple persons in address book, 2 matching keywords and 1 non-matching keyword
-//         * -> 2 persons found
-//         */
-//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX
-//                + "Friend Husband NonMatchingKeyWord";
-//        assertCommandSuccess(command, expectedModel);
-//        assertSelectedCardUnchanged();
-//
-//        /* Case: undo previous find command -> rejected */
-//        command = UndoCommand.COMMAND_WORD;
-//        String expectedResultMessage = UndoCommand.MESSAGE_FAILURE;
-//        assertCommandFailure(command, expectedResultMessage);
-//
-//        /* Case: redo previous find command -> rejected */
-//        command = RedoCommand.COMMAND_WORD;
-//        expectedResultMessage = RedoCommand.MESSAGE_FAILURE;
-//        assertCommandFailure(command, expectedResultMessage);
-//
-//        /* Case: find person in address book, keyword is same as name but of different case -> 1 person found */
-//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "FrIenD";
-//        assertCommandSuccess(command, expectedModel);
-//        assertSelectedCardUnchanged();
-//
-//        /* Case: find person in address book, keyword is substring of name -> 0 persons found */
-//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Fri";
-//        ModelHelper.setFilteredList(expectedModel);
-//        assertCommandSuccess(command, expectedModel);
-//        assertSelectedCardUnchanged();
-//
-//        /* Case: find person in address book, name is substring of keyword -> 0 persons found */
-//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Friends";
-//        ModelHelper.setFilteredList(expectedModel);
-//        assertCommandSuccess(command, expectedModel);
-//        assertSelectedCardUnchanged();
-//
-//        /* Case: find tag not in address book -> 0 persons found */
-//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Wife";
-//        assertCommandSuccess(command, expectedModel);
-//        assertSelectedCardUnchanged();
-//
-//        /* Case: find phone number of person in address book -> 0 persons found */
-//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + DANIEL.getPhone().value;
-//        assertCommandSuccess(command, expectedModel);
-//        assertSelectedCardUnchanged();
-//
-//        /* Case: find address of person in address book -> 0 persons found */
-//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + DANIEL.getAddress().value;
-//        assertCommandSuccess(command, expectedModel);
-//        assertSelectedCardUnchanged();
-//
-//        /* Case: find email of person in address book -> 0 persons found */
-//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + DANIEL.getEmail().value;
-//        assertCommandSuccess(command, expectedModel);
-//        assertSelectedCardUnchanged();
-//
-//        /* Case: find while a person is selected -> selected card deselected */
-//        showAllPersons();
-//        selectPerson(Index.fromOneBased(1));
-//        assert !getPersonListPanel().getHandleToSelectedCard().getTags().toString().equals(AMY.getTags().toString());
-//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + "Friend";
-//        ModelHelper.setFilteredList(expectedModel, AMY, BOB);
-//        assertCommandSuccess(command, expectedModel);
-//        assertSelectedCardDeselected();
-//
-//        /* Case: find tag in empty address book -> 0 persons found */
-//        executeCommand(ClearCommand.COMMAND_WORD);
-//        assert getModel().getAddressBook().getPersonList().size() == 0;
-//        command = FindCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD_TAG_PREFIX + VALID_TAG_FRIEND;
-//        expectedModel = getModel();
-//        ModelHelper.setFilteredList(expectedModel, AMY, BOB);
-//        assertCommandSuccess(command, expectedModel);
-//        assertSelectedCardUnchanged();
-//
-//        /* Case: mixed case command word -> rejected */
-//        command = "FiNd t/Meier";
-//        assertCommandFailure(command, MESSAGE_UNKNOWN_COMMAND);
-//    }
 
     /**
      * Executes {@code command} and verifies that the command box displays an empty string, the result display


### PR DESCRIPTION
The FindCommand is now able to find by Name and Tag using the prefixes "n/ " and "t/ " respectively. 

To complete:
- [ ] New JUnit tests for finding by Tags.
- [x] Developer Guide
- [ ] User Guide

For #30 